### PR TITLE
Remove trailing new line('\r\n') and whitespace

### DIFF
--- a/twder/api.py
+++ b/twder/api.py
@@ -35,10 +35,10 @@ def now_all():
         key = match(r".*\((\w+)\)", full_name).group(1)
         __NAME_DICT[key] = full_name
 
-        cash_buy = tds[1].text
-        cash_sell = tds[2].text
-        rate_buy = tds[3].text
-        rate_sell = tds[4].text
+        cash_buy = tds[1].text.strip()
+        cash_sell = tds[2].text.strip()
+        rate_buy = tds[3].text.strip()
+        rate_sell = tds[4].text.strip()
 
         ret[key] = (quote_time, cash_buy, cash_sell, rate_buy, rate_sell)
 


### PR DESCRIPTION
目前抓取匯率之後，在即期匯率會抓到換行符號
e.g.: ('2021/01/06 10:51', '27.555', '28.225', '\r\n                        27.905\r\n                    ', '\r\n                        28.005\r\n                    ')
我加上了strip來移除它